### PR TITLE
Add periodic timer to remove the inactive consumers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,10 @@
 		</dependency>
 		<dependency>
 			<groupId>io.quarkus</groupId>
+			<artifactId>quarkus-scheduler</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.quarkus</groupId>
 			<artifactId>quarkus-opentelemetry</artifactId>
 		</dependency>
 		<dependency>

--- a/src/main/java/io/strimzi/kafka/bridge/quarkus/config/HttpConfig.java
+++ b/src/main/java/io/strimzi/kafka/bridge/quarkus/config/HttpConfig.java
@@ -36,8 +36,8 @@ public interface HttpConfig {
     /**
      * @return HTTP consumer timeouts
      */
-    @WithDefault("-1")
-    long timeoutSeconds();
+    @WithDefault("-1s")
+    String timeoutSeconds();
 
     /**
      * @return HTTP consumer related configuration


### PR DESCRIPTION
This PR adds the mechanism to automatically shut down the consumer if it is running and has passed out the given timeout.

The timeout is inactive by default.  

The timeout should be given in second in the `application.properties` file like this

```
http.timeoutSeconds = 3s ( timeout of 3s)
```

