### PR TITLE
Quartz scheduler approach for deleting Inactive consumers in Strimzi Bridge

### DIFF
--- a/config/application.properties
+++ b/config/application.properties
@@ -39,3 +39,6 @@ quarkus.application.name=strimzi-kafka-bridge
 quarkus.opentelemetry.tracer.resource-attributes=service.name=${OTEL_SERVICE_NAME:strimzi-kafka-bridge-${bridge.id}}
 #if the OTEL_EXPORTER_OTLP_ENDPOINT, it's using http://localhost:4317 by default
 quarkus.opentelemetry.tracer.exporter.otlp.endpoint=${OTEL_EXPORTER_OTLP_ENDPOINT}
+
+#This property is required to allow scheduling the periodic task programmatically(i.e. inactive consumers check)
+quarkus.quartz.start-mode=forced

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,10 @@
 		</dependency>
 		<dependency>
 			<groupId>io.quarkus</groupId>
+			<artifactId>quarkus-quartz</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.quarkus</groupId>
 			<artifactId>quarkus-opentelemetry</artifactId>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
This PR adds the mechanism to automatically shut down the consumer if it is running and has passed out the given timeout.

The timeout is inactive by default.

The timeout should be given in second in the application.properties file like this

http.timeoutSeconds = 3000