### PR TITLE
Add Http related and Kafka related metrics to the Bridge

### DIFF
--- a/config/application.properties
+++ b/config/application.properties
@@ -17,7 +17,7 @@ kafka.consumer.auto.offset.reset=earliest
 
 #HTTP related settings
 http.host=0.0.0.0
-http.port=8082
+http.port=8080
 #Enable CORS
 http.cors.enabled=false
 http.cors.allowedOrigins=*
@@ -31,9 +31,6 @@ http.producer.enabled=true
 
 #Quarkus related configuration
 quarkus.application.name=strimzi-kafka-bridge
-
-# Quarkus property to disable default prometheus registry
-quarkus.micrometer.export.prometheus.default-registry=false
 
 #Logging
 quarkus.log.category."http.openapi.operation.healthy".level=WARN
@@ -53,3 +50,6 @@ quarkus.quartz.start-mode=forced
 
 #This property is required to set the predefined headers
 quarkus.http.cors.headers=x-requested-with,x-forwarded-proto,x-forwarded-host,access-control-allow-origin,access-control-allow-methods,origin,content-type,content-length,accept
+
+# Quarkus property to disable default prometheus registry
+quarkus.micrometer.export.prometheus.default-registry=false

--- a/config/application.properties
+++ b/config/application.properties
@@ -17,7 +17,7 @@ kafka.consumer.auto.offset.reset=earliest
 
 #HTTP related settings
 http.host=0.0.0.0
-http.port=8082
+http.port=8080
 #Enable CORS
 http.cors.enabled=false
 http.cors.allowedOrigins=*

--- a/config/application.properties
+++ b/config/application.properties
@@ -53,3 +53,5 @@ quarkus.http.cors.headers=x-requested-with,x-forwarded-proto,x-forwarded-host,ac
 
 # Quarkus property to disable default prometheus registry
 quarkus.micrometer.export.prometheus.default-registry=false
+
+quarkus.micrometer.export.prometheus.path=/metrics

--- a/config/application.properties
+++ b/config/application.properties
@@ -17,7 +17,7 @@ kafka.consumer.auto.offset.reset=earliest
 
 #HTTP related settings
 http.host=0.0.0.0
-http.port=8080
+http.port=8082
 #Enable CORS
 http.cors.enabled=false
 http.cors.allowedOrigins=*

--- a/config/application.properties
+++ b/config/application.properties
@@ -54,4 +54,5 @@ quarkus.http.cors.headers=x-requested-with,x-forwarded-proto,x-forwarded-host,ac
 # Quarkus property to disable default prometheus registry
 quarkus.micrometer.export.prometheus.default-registry=false
 
+# Quarkus property used to set the prometheus metrics endpoint
 quarkus.micrometer.export.prometheus.path=/metrics

--- a/config/application.properties
+++ b/config/application.properties
@@ -17,7 +17,7 @@ kafka.consumer.auto.offset.reset=earliest
 
 #HTTP related settings
 http.host=0.0.0.0
-http.port=8080
+http.port=8082
 #Enable CORS
 http.cors.enabled=false
 http.cors.allowedOrigins=*
@@ -31,6 +31,9 @@ http.producer.enabled=true
 
 #Quarkus related configuration
 quarkus.application.name=strimzi-kafka-bridge
+
+# Quarkus property to disable default prometheus registry
+quarkus.micrometer.export.prometheus.default-registry=false
 
 #Logging
 quarkus.log.category."http.openapi.operation.healthy".level=WARN

--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,10 @@
 		</dependency>
 		<dependency>
 			<groupId>io.quarkus</groupId>
+			<artifactId>quarkus-micrometer-registry-prometheus</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.quarkus</groupId>
 			<artifactId>quarkus-opentelemetry</artifactId>
 		</dependency>
 		<dependency>
@@ -314,24 +318,9 @@
 			<version>${micrometer.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>io.micrometer</groupId>
-			<artifactId>micrometer-registry-prometheus</artifactId>
-			<version>${micrometer.version}</version>
-		</dependency>
-		<dependency>
 			<groupId>io.prometheus.jmx</groupId>
 			<artifactId>collector</artifactId>
 			<version>${jmx-prometheus-collector.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>io.prometheus</groupId>
-			<artifactId>simpleclient</artifactId>
-			<version>${prometheus-simpleclient.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>io.prometheus</groupId>
-			<artifactId>simpleclient_common</artifactId>
-			<version>${prometheus-simpleclient.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-cli</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -323,6 +323,16 @@
 			<version>${jmx-prometheus-collector.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>io.prometheus</groupId>
+			<artifactId>simpleclient</artifactId>
+			<version>${prometheus-simpleclient.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.prometheus</groupId>
+			<artifactId>simpleclient_common</artifactId>
+			<version>${prometheus-simpleclient.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>commons-cli</groupId>
 			<artifactId>commons-cli</artifactId>
 			<version>${commons-cli.version}</version>

--- a/src/main/java/io/strimzi/kafka/bridge/quarkus/CustomMeterRegistryProducer.java
+++ b/src/main/java/io/strimzi/kafka/bridge/quarkus/CustomMeterRegistryProducer.java
@@ -73,9 +73,7 @@ public class CustomMeterRegistryProducer extends PrometheusMeterRegistry {
 
         @Override
         public String tagKey(String key) {
-            String tag = key.replace("uri", "path").replace("status", "code");;
-
-            System.out.println(key);
+            String tag = key.replace("uri", "path").replace("status", "code");
             return super.tagKey(tag);
         }
     }

--- a/src/main/java/io/strimzi/kafka/bridge/quarkus/CustomMeterRegistryProducer.java
+++ b/src/main/java/io/strimzi/kafka/bridge/quarkus/CustomMeterRegistryProducer.java
@@ -70,6 +70,14 @@ public class CustomMeterRegistryProducer extends PrometheusMeterRegistry {
             String metricName = name.startsWith("http.") ? "strimzi.bridge." + name : name;
             return super.name(metricName, type, baseUnit);
         }
+
+        @Override
+        public String tagKey(String key) {
+            String tag = key.replace("uri", "path").replace("status", "code");;
+
+            System.out.println(key);
+            return super.tagKey(tag);
+        }
     }
 }
 

--- a/src/main/java/io/strimzi/kafka/bridge/quarkus/CustomMeterRegistryProducer.java
+++ b/src/main/java/io/strimzi/kafka/bridge/quarkus/CustomMeterRegistryProducer.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.kafka.bridge.quarkus;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.micrometer.prometheus.PrometheusNamingConvention;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * Used for scraping and reporting metrics in Prometheus format
+ */
+@Singleton
+public class CustomMeterRegistryProducer extends PrometheusMeterRegistry {
+
+    @Inject
+    JmxCollectorRegistry restJmxCollectorRegistry;
+
+    @PostConstruct
+    void init() {
+        this.config().namingConvention(new CustomMeterRegistryProducer.MetricsNamingConvention());
+    }
+
+    /**
+     * Came in as part of extending `PrometheusMeterRegistry since
+     * it has no default constructors available
+     */
+    private CustomMeterRegistryProducer(PrometheusConfig config) {
+        super(config);
+    }
+
+    @Produces
+    @Singleton
+    CustomMeterRegistryProducer createPrometheusMeterRegistry() {
+        return this;
+    }
+
+    /**
+     * Scrape metrics on the provided registries returning them in the Prometheus format
+     *
+     * @return metrics in Prometheus format as String
+     */
+    @Override
+    public String scrape() {
+        StringBuilder sb = new StringBuilder();
+
+        if (Boolean.parseBoolean(System.getenv("KAFKA_BRIDGE_METRICS_ENABLED"))) {
+
+            if (restJmxCollectorRegistry != null) {
+                sb.append(restJmxCollectorRegistry.scrape());
+            }
+
+            sb.append(super.scrape());
+        }
+
+        return sb.toString();
+    }
+
+    private static class MetricsNamingConvention extends PrometheusNamingConvention {
+        @Override
+        public String name(String name, Meter.Type type, String baseUnit) {
+            String metricName = name.startsWith("http.") ? "strimzi.bridge." + name : name;
+            return super.name(metricName, type, baseUnit);
+        }
+    }
+}
+

--- a/src/main/java/io/strimzi/kafka/bridge/quarkus/CustomMeterRegistryProducer.java
+++ b/src/main/java/io/strimzi/kafka/bridge/quarkus/CustomMeterRegistryProducer.java
@@ -6,6 +6,7 @@
 package io.strimzi.kafka.bridge.quarkus;
 
 import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.micrometer.prometheus.PrometheusNamingConvention;
@@ -26,6 +27,8 @@ public class CustomMeterRegistryProducer extends PrometheusMeterRegistry {
 
     @PostConstruct
     void init() {
+        this.config().meterFilter(
+                MeterFilter.deny(meter -> "/metrics".equals(meter.getTag("uri"))));
         this.config().namingConvention(new CustomMeterRegistryProducer.MetricsNamingConvention());
     }
 
@@ -51,13 +54,10 @@ public class CustomMeterRegistryProducer extends PrometheusMeterRegistry {
     @Override
     public String scrape() {
         StringBuilder sb = new StringBuilder();
-
         if (Boolean.parseBoolean(System.getenv("KAFKA_BRIDGE_METRICS_ENABLED"))) {
-
             if (restJmxCollectorRegistry != null) {
                 sb.append(restJmxCollectorRegistry.scrape());
             }
-
             sb.append(super.scrape());
         }
 

--- a/src/main/java/io/strimzi/kafka/bridge/quarkus/JmxCollectorRegistry.java
+++ b/src/main/java/io/strimzi/kafka/bridge/quarkus/JmxCollectorRegistry.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.kafka.bridge.quarkus;
+
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.exporter.common.TextFormat;
+import io.prometheus.jmx.JmxCollector;
+import io.quarkus.runtime.Startup;
+import io.strimzi.kafka.bridge.Application;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.management.MalformedObjectNameException;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
+
+/**
+ * Allow to collect JMX metrics exposing them in the Prometheus format
+ */
+@Startup
+public class JmxCollectorRegistry {
+
+    private CollectorRegistry collectorRegistry;
+
+    @PostConstruct
+    public void init() throws MalformedObjectNameException, IOException {
+        InputStream is = Application.class.getClassLoader().getResourceAsStream("jmx_metrics_config.yaml");
+        if (is == null) {
+            // this should not happen because the JMX metrics configuration is baked into the jar
+            throw new RuntimeException("JMX metrics configuration not found");
+        }
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
+            String yaml = reader
+                    .lines()
+                    .collect(Collectors.joining("\n"));
+            new JmxCollector(yaml).register();
+            collectorRegistry = CollectorRegistry.defaultRegistry;
+        }
+    }
+
+    @PreDestroy
+    public void destroy() {
+        collectorRegistry.clear();
+    }
+
+    /**
+     * @return Content that should be included in the response body for an endpoint designated for
+     * Prometheus to scrape from.
+     */
+    public String scrape() {
+        Writer writer = new StringWriter();
+        try {
+            TextFormat.write004(writer, collectorRegistry.metricFamilySamples());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return writer.toString();
+    }
+}

--- a/src/main/java/io/strimzi/kafka/bridge/quarkus/RestBridgeMeterRegistryProducer.java
+++ b/src/main/java/io/strimzi/kafka/bridge/quarkus/RestBridgeMeterRegistryProducer.java
@@ -18,8 +18,8 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 /**
- * Scrapes Quarkus http server related metrics and the Kafka related metrics coming through JMX collector
- * and generates a custom prometheus meter registry based upon it.
+ * Provides a custom Prometheus registry able to host both Quarkus built-in HTTP related metrics
+ * and Kafka clients related metrics coming through JMX collector
  */
 @Singleton
 public class RestBridgeMeterRegistryProducer extends PrometheusMeterRegistry {
@@ -52,7 +52,8 @@ public class RestBridgeMeterRegistryProducer extends PrometheusMeterRegistry {
     }
 
     /**
-     * Scrape metrics on the provided registries returning them in the Prometheus format
+     * Scrape Quarkus built-in meter registry for HTTP related metrics and
+     * JMX collector registry for Kafka clients related metrics
      *
      * @return metrics in Prometheus format as String
      */


### PR DESCRIPTION
This is based on Erin's suggestion. We are creating our own custom Meter registry which automatically catched up by quarkus. So now Quarkus will be using our registry and we extended the prometheus registry providing us the way to directly override the `scrape()` method which is being used by Quarkus.