### PR TITLE
Remove the worker pool metrics 

### DIFF
--- a/src/main/java/io/strimzi/kafka/bridge/quarkus/RestBridgeMeterRegistryProducer.java
+++ b/src/main/java/io/strimzi/kafka/bridge/quarkus/RestBridgeMeterRegistryProducer.java
@@ -34,6 +34,8 @@ public class RestBridgeMeterRegistryProducer extends PrometheusMeterRegistry {
     void init() {
         this.config().meterFilter(
                 MeterFilter.deny(meter -> "/metrics".equals(meter.getTag("uri"))));
+        this.config().meterFilter(
+                MeterFilter.denyNameStartsWith("worker_pool"));
         this.config().namingConvention(new RestBridgeMeterRegistryProducer.MetricsNamingConvention());
     }
 


### PR DESCRIPTION
This PR removes `worker pool` metrics like these - 
```
# TYPE worker_pool_active gauge
# HELP worker_pool_active The number of resources from the pool currently used
worker_pool_active{pool_name="vert.x-internal-blocking",pool_type="worker"} 0.0
worker_pool_active{pool_name="vert.x-worker-thread",pool_type="worker"} 1.0
# TYPE worker_pool_usage_seconds summary
# HELP worker_pool_usage_seconds Time spent using resources from the pool
worker_pool_usage_seconds_count{pool_name="vert.x-internal-blocking",pool_type="worker"} 0.0
worker_pool_usage_seconds_sum{pool_name="vert.x-internal-blocking",pool_type="worker"} 0.0
```
