### PR TITLE
Some configuration refactoring

### DIFF
--- a/config/application.properties
+++ b/config/application.properties
@@ -27,24 +27,6 @@ http.consumer.enabled=true
 #Enable producer
 http.producer.enabled=true
 
-#Quarkus related configuration
-quarkus.application.name=strimzi-kafka-bridge
-
 #Logging
 quarkus.log.category."http.openapi.operation.healthy".level=WARN
 quarkus.log.category."http.openapi.operation.ready".level=DEBUG
-
-#WARNING: don't change this following configuration.
-
-#OpenTelemetry support
-#It's done so that you can rely on the usual way to configure OpenTelemetry by setting OTEL_SERVICE_NAME and OTEL_EXPORTER_OTLP_ENDPOINT environment variables
-#using OTEL_SERVICE_NAME as usual or a preformatted service name based on the bridge.id
-quarkus.otel.resource.attributes=service.name=${OTEL_SERVICE_NAME:strimzi-kafka-bridge-${bridge.id}}
-#if the OTEL_EXPORTER_OTLP_ENDPOINT, it's using http://localhost:4317 by default
-quarkus.otel.exporter.otlp.traces.endpoint=${OTEL_EXPORTER_OTLP_ENDPOINT}
-
-#This property is required to allow scheduling the periodic task programmatically(i.e. inactive consumers check)
-quarkus.scheduler.start-mode=forced
-
-#This property is required to set the predefined headers
-quarkus.http.cors.headers=x-requested-with,x-forwarded-proto,x-forwarded-host,access-control-allow-origin,access-control-allow-methods,origin,content-type,content-length,accept

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -106,6 +106,7 @@ public class HttpBridge {
 
     @PostConstruct
     public void init() {
+        log.infof("HTTP-Kafka Bridge configuration %s", this.configurationAsString());
         this.timestampMap = new HashMap<>();
         this.httpBridgeContext = new HttpBridgeContext<>();
         HttpAdminBridgeEndpoint adminClientEndpoint = new HttpAdminBridgeEndpoint(this.bridgeConfig, this.kafkaConfig);
@@ -120,7 +121,6 @@ public class HttpBridge {
         log.infof("HTTP-Kafka Bridge started and listening on port %s", this.httpConfig.port());
         log.infof("HTTP-Kafka Bridge bootstrap servers %s",
                 this.kafkaConfig.common().get(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG));
-        log.infof("HTTP-Kafka Bridge configuration %s", this.configurationAsString());
     }
 
     @PreDestroy
@@ -608,7 +608,8 @@ public class HttpBridge {
 
     private void scheduleInactiveConsumersDeletionJob(long timeout) {
         this.scheduler.newJob("inactiveConsumersDeletion")
-                .setCron(String.format("0/%s * * * * ?", timeout / 2))
+                // interval has to be <time>s, i.e. 30s
+                .setInterval(String.format("%ds", timeout / 2))
                 .setTask(scheduledExecution -> {
                     this.deleteInactiveConsumers();
                 })

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,17 @@
-smallrye.config.mapping.validate-unknown=false
+#Quarkus related configuration
+quarkus.application.name=strimzi-kafka-bridge
+
+#WARNING: don't change this following configuration.
+
+#OpenTelemetry support
+#It's done so that you can rely on the usual way to configure OpenTelemetry by setting OTEL_SERVICE_NAME and OTEL_EXPORTER_OTLP_ENDPOINT environment variables
+#using OTEL_SERVICE_NAME as usual or a preformatted service name based on the bridge.id
+quarkus.otel.resource.attributes=service.name=${OTEL_SERVICE_NAME:strimzi-kafka-bridge-${bridge.id}}
+#if the OTEL_EXPORTER_OTLP_ENDPOINT, it's using http://localhost:4317 by default
+quarkus.otel.exporter.otlp.traces.endpoint=${OTEL_EXPORTER_OTLP_ENDPOINT}
+
+#This property is required to allow scheduling the periodic task programmatically(i.e. inactive consumers check)
+quarkus.scheduler.start-mode=forced
+
+#This property is required to set the predefined headers
+quarkus.http.cors.headers=x-requested-with,x-forwarded-proto,x-forwarded-host,access-control-allow-origin,access-control-allow-methods,origin,content-type,content-length,accept


### PR DESCRIPTION
Moved hard-coded Quarkus parameters into the backed properties file
Moved to use interval instead of cron for inactive consumers job 
Logging bridge configuration as first thing at startup